### PR TITLE
Fix MSYS/Git Bash path conversion breaking compiler on Windows

### DIFF
--- a/al-compile
+++ b/al-compile
@@ -34,6 +34,13 @@ detect_platform() {
 
 PLATFORM=$(detect_platform)
 
+# Disable MSYS/Git Bash automatic path conversion on Windows.
+# Without this, arguments like /project:. and /analyzer:... get mangled
+# into Windows paths (e.g. C:/project:.) before reaching the AL compiler.
+if [[ "$PLATFORM" == "windows" ]]; then
+    export MSYS_NO_PATHCONV=1
+fi
+
 # Set platform-specific paths
 case "$PLATFORM" in
     windows)


### PR DESCRIPTION
## Summary
- On Windows with Git Bash (MSYS2), arguments starting with `/` like `/project:.` and `/analyzer:...` are automatically converted to Windows paths by the MSYS layer before reaching the AL compiler
- This causes `AL1049: A project without a manifest must have the /out option specified` errors because `/project:.` gets mangled
- Fix: set `MSYS_NO_PATHCONV=1` when platform is `windows`, right after `detect_platform()`
- Linux, macOS, and WSL are unaffected (the fix is conditional)

## Context
Claude Code on Windows uses Git Bash as its shell. Every invocation of `al-compile` fails with AL1049 due to MSYS path conversion. This is the standard fix for Windows CLI tools that use `/`-prefixed arguments in Git Bash.

## Test plan
- [x] Verified on Windows 11 with Git Bash: `al-compile` now compiles successfully (26 files, 0 errors)
- [ ] Verify no impact on Linux (no MSYS layer, condition is skipped)
- [ ] Verify no impact on WSL (platform detected as `wsl`, not `windows`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)